### PR TITLE
add framer command line parameter

### DIFF
--- a/example-tcp-udp.py
+++ b/example-tcp-udp.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
     argparser.add_argument("port", type=int, help="Modbus TCP/UDP port")
     argparser.add_argument("--udp", action="store_true", default=False, help="Use Modbus UDP mode")
     argparser.add_argument("--timeout", type=int, default=1, help="Connection timeout")
+    argparser.add_argument("--framer", type=str, default=None, help="Framer (rtu|socket|ascii|binary)")
     argparser.add_argument("--unit", type=int, default=1, help="Modbus device address")
     argparser.add_argument("--json", action="store_true", default=False, help="Output as JSON")
     args = argparser.parse_args()
@@ -19,6 +20,7 @@ if __name__ == "__main__":
         host=args.host,
         port=args.port,
         timeout=args.timeout,
+        framer=args.framer,
         unit=args.unit,
         udp=args.udp 
     )


### PR DESCRIPTION
A common Modbus application is to connect to a remote RTU device over TCP. Problem is that Modbus RTU and Modbus TCP are different protocols, implemented by the `ModbusFramer` class in `pymodbus`. This change adds a `framer` parameter to the `Meter` constructor that gives the user the option to use a non-default framer. It also adds a command line parameter to the `example-tcp-udp.py` script to pass the framer option to the `SDM120` meter.