### PR TITLE
Changed Endian.Big into Endian.BIG

### DIFF
--- a/src/sdm_modbus/meter.py
+++ b/src/sdm_modbus/meter.py
@@ -51,9 +51,9 @@ class Meter:
     parity = "N"
     baud = 38400
 
-    wordorder = Endian.Big
-    byteorder = Endian.Big
-    
+    wordorder = Endian.BIG
+    byteorder = Endian.BIG
+
     udp = False
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
In order to get this module running on my Raspberry Pi. 

`pymodbus.constants` uses `Endian.BIG` instead of `Endian.Big`