### PR TITLE
meter.py adjusted to new pymodbus syntax to solve issue #35 of origin…

### DIFF
--- a/src/sdm_modbus/meter.py
+++ b/src/sdm_modbus/meter.py
@@ -8,8 +8,8 @@ from pymodbus.client import ModbusUdpClient
 from pymodbus.client import ModbusSerialClient
 from pymodbus.payload import BinaryPayloadBuilder
 from pymodbus.payload import BinaryPayloadDecoder
-from pymodbus.pdu.register_read_message import ReadInputRegistersResponse
-from pymodbus.pdu.register_read_message import ReadHoldingRegistersResponse
+from pymodbus.pdu.register_message import ReadInputRegistersResponse
+from pymodbus.pdu.register_message import ReadHoldingRegistersResponse
 
 
 class connectionType(enum.Enum):
@@ -132,7 +132,7 @@ class Meter:
 
                 self.mode = connectionType.RTU
                 self.client = ModbusSerialClient(
-                    method="rtu",
+#                    method="rtu",
                     port=self.device,
                     stopbits=self.stopbits,
                     parity=self.parity,


### PR DESCRIPTION
Meter.py file changed to adjust the new pymodbus syntax.