### PR TITLE
fix: required pymodus version 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    pymodbus >= 3.7.2
+    pymodbus >= 3.8.0
     pyserial-asyncio >= 0.6.0
 
 [options.packages.find]

--- a/src/sdm_modbus/meter.py
+++ b/src/sdm_modbus/meter.py
@@ -130,7 +130,6 @@ class Meter:
 
                 self.mode = connectionType.RTU
                 self.client = ModbusSerialClient(
-                    method="rtu",
                     port=self.device,
                     stopbits=self.stopbits,
                     parity=self.parity,


### PR DESCRIPTION
Because `pymodbus.pdu.register_message` starts avaliable in v3.8.0.